### PR TITLE
Remove busybox dpkg from Docker image

### DIFF
--- a/addon-resizer/Dockerfile
+++ b/addon-resizer/Dockerfile
@@ -20,4 +20,5 @@ RUN cd /go/src/k8s.io/contrib/addon-resizer && \
 
 FROM busybox:1.31.0
 COPY --from=builder /go/src/k8s.io/contrib/addon-resizer/build/pod_nanny pod_nanny
+RUN rm -rf /bin/dpkg
 CMD ./pod_nanny


### PR DESCRIPTION
As per other busybox images in use, removing package manager for security purposes.